### PR TITLE
Use L.Util.extend rather than $.extend

### DIFF
--- a/src/locationfilter.js
+++ b/src/locationfilter.js
@@ -139,7 +139,7 @@ L.LocationFilter = L.Class.extend({
             fillOpacity: 0.3,
             clickable: false,
         };
-        options = $.extend({}, defaultOptions, options);
+        options = L.Util.extend(defaultOptions, options);
         var rect = new L.Rectangle(bounds, options);
         rect.addTo(this._layer);
         return rect;
@@ -311,9 +311,7 @@ L.LocationFilter = L.Class.extend({
 
     /* Reposition all rectangles and markers to the current filter bounds. */    
     _draw: function(options) {
-        options = $.extend({}, {
-            repositionResizeMarkers: true
-        }, options);
+        options = L.Util.extend({repositionResizeMarkers: true}, options);
 
         // Calculate filter bounds
         this._calculateBounds();


### PR DESCRIPTION
This removes the jQuery dependency. Also, both uses pass a local variable or
temporary as the destination, so do not require an empty object as the first
argument.
