### PR TITLE
Use Leaflet's events rather than callback options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,19 @@ var isEnabled = locationFilter.isEnabled();
 
 **enable** (optional): Set to true to enable the filter as soon as it is added to the map. Defaults to false.
 
-#### Callbacks
-All callbacks are given one argument; the current bounds of the location filter.
+#### Events
 
-**onChange** (optional): Called every time the location filter changes size or position.
+**change**: Fired when the location filter changes size or position.
 
-**onEnabled**: (optional): Called when the location filter gets enabled.
+**enabled**:: Fired when the location filter gets enabled.
 
-**onDisabled** (optional): Called when the location filter gets disabled.
+**disabled**: Fired when the location filter gets disabled.
 
-**onEnableClick** (optional): Called when the user clicks the enable button.
+**enableClick**: Fired when the user clicks the enable button.
 
-**onDisableClick** (optional): Called when the user clicks the disable button.
+**disableClick**: Fired when the user clicks the disable button.
 
-**onAdjustToZoomClick** (optional): Called when the user clicks the adjust button.
+**adjustToZoomClick**: Fired when the user clicks the adjust button.
 
 ### License
 leaflet-locationfilter is free software, and may be redistributed under the MIT-LICENSE.

--- a/src/locationfilter.js
+++ b/src/locationfilter.js
@@ -91,6 +91,8 @@ L.Control.ButtonContainer = L.Control.extend({
 });
 
 L.LocationFilter = L.Class.extend({
+    includes: L.Mixin.Events,
+
     options: {
         enableButton: {
             enableText: "Select area",
@@ -136,7 +138,7 @@ L.LocationFilter = L.Class.extend({
         this._sw = bounds.getSouthWest();
         this._se = bounds.getSouthEast();
         this._draw();
-        this._callCallback("onChange");
+        this.fire("change");
     },
 
     isEnabled: function() {
@@ -239,22 +241,13 @@ L.LocationFilter = L.Class.extend({
         this._setupDragendListener(marker);
     },
 
-    /* Call the callback (given by name) if it was supplied in options */
-    _callCallback: function(callbackName) {
-        if (this.options[callbackName]) {
-            this.options[callbackName](this.getBounds());
-        }
-    },
-
-    /* Call the onChange callback whenever dragend is triggered on the
+    /* Emit a change event whenever dragend is triggered on the
        given marker */
     _setupDragendListener: function(marker) {
-        if (this.options.onChange) {
-            var that = this;
-            marker.on('dragend', function(e) {
-                that._callCallback("onChange");
-            });
-        }
+        var that = this;
+        marker.on('dragend', function(e) {
+            that.fire("change");
+        });
     },
 
     /* Create bounds for the mask rectangles and the location
@@ -411,8 +404,8 @@ L.LocationFilter = L.Class.extend({
 
         this._enabled = true;
         
-        // Call the enabled callback
-        this._callCallback("onEnabled");
+        // Fire the enabled event
+        this.fire("enabled");
     },
 
     /* Disable the location filter */
@@ -440,8 +433,8 @@ L.LocationFilter = L.Class.extend({
 
         this._enabled = false;
 
-        // Call the disabled callback
-        this._callCallback("onDisabled");
+        // Fire the disabled event
+        this.fire("disabled");
     },
 
     /* Create a button that allows the user to adjust the location
@@ -454,7 +447,7 @@ L.LocationFilter = L.Class.extend({
             
             onClick: function(event) {
                 that._adjustToMap();
-                that._callCallback("onAdjustToZoomClick");
+                that.fire("adjustToZoomClick");
             }
         }).addTo(this._buttonContainer);
     },
@@ -474,11 +467,11 @@ L.LocationFilter = L.Class.extend({
                     if (!that._enabled) {
                         // Enable the location filter
                         that.enable();
-                        that._callCallback("onEnableClick");
+                        that.fire("enableClick");
                     } else {
                         // Disable the location filter
                         that.disable();
-                        that._callCallback("onDisableClick");
+                        that.fire("disableClick");
                     }
                 }
             }).addTo(this._buttonContainer);

--- a/src/locationfilter.js
+++ b/src/locationfilter.js
@@ -138,7 +138,7 @@ L.LocationFilter = L.Class.extend({
         this._sw = bounds.getSouthWest();
         this._se = bounds.getSouthEast();
         this._draw();
-        this.fire("change");
+        this.fire("change", {bounds: bounds});
     },
 
     isEnabled: function() {
@@ -246,7 +246,7 @@ L.LocationFilter = L.Class.extend({
     _setupDragendListener: function(marker) {
         var that = this;
         marker.on('dragend', function(e) {
-            that.fire("change");
+            that.fire("change", {bounds: that.getBounds()});
         });
     },
 


### PR DESCRIPTION
Leaflet has a built-in [event system](http://leaflet.cloudmade.com/reference.html#events). It would be more consistent with built-in Leaflet controls and other plugins to expose the change/enabled/disabled events using that API rather than the current onChange/onEnabled/onDisabled options. It would also be more flexible (for example, it would allow multiple callbacks to be bound to an event).
