### PR TITLE
selection not highlighted in Opera

### DIFF
--- a/src/locationfilter.js
+++ b/src/locationfilter.js
@@ -294,7 +294,7 @@ L.LocationFilter = L.Class.extend({
         this._eastRect = this._drawRectangle(this._eastBounds);
         this._southRect = this._drawRectangle(this._southBounds);
         this._innerRect = this._drawRectangle(this.getBounds(), {
-            fillColor: "transparent",
+            fillOpacity: 0,
             stroke: true,
             color: "white",
             weight: 1,


### PR DESCRIPTION
"transparent" doesn't seem to be a valid color for SVG (c.f. http://www.w3.org/TR/SVG/types.html#DataTypeColor). Better use fillOpacity=0 instead.
