### PR TITLE
Move this._layer initialization to _initialDraw

### DIFF
--- a/src/locationfilter.js
+++ b/src/locationfilter.js
@@ -114,7 +114,6 @@ L.LocationFilter = L.Class.extend({
 
     onAdd: function(map) {
         this._map = map;
-        this._layer = new L.LayerGroup();
 
         if (this.options.enableButton || this.options.adjustButton) {
             this._initializeButtonContainer();
@@ -284,6 +283,8 @@ L.LocationFilter = L.Class.extend({
         if (this._initialDrawCalled) {
             return;
         }
+
+        this._layer = new L.LayerGroup();
 
         // Calculate filter bounds
         this._calculateBounds();


### PR DESCRIPTION
This fixes a bug where, when the location filter was added, removed, and
re-added to a map, it would not display. This happened because the re-add
would reinitialize `this._layer` but not call `_initialDraw`, which sets up
this._layer.
