### PR TITLE
remove unused _drawResizeMarker method arguments

### DIFF
--- a/src/locationfilter.js
+++ b/src/locationfilter.js
@@ -207,7 +207,7 @@ L.LocationFilter = L.Class.extend({
     },
 
     /* Draw a resize marker */
-    _drawResizeMarker: function(point, latFollower, lngFollower, otherPos) {
+    _drawResizeMarker: function(point) {
         return this._drawImageMarker(point, {
             "className": "location-filter resize-marker",
             "anchor": [7, 6],


### PR DESCRIPTION
The arguments `latFollower`, `lngFollower` and `otherPos` are neither passed in any of the calls to `L.LocationFilter._drawResizeMarker`, nor would they have been used by that method's current implementation.
